### PR TITLE
Create known.toml for implementing leftwm/leftwm#27

### DIFF
--- a/known.toml
+++ b/known.toml
@@ -1,0 +1,34 @@
+[[theme]]
+name = "Orange Forest"
+repository = "https://github.com/PVautour/leftwm-theme-orange-forest/"
+commit = "*"
+version = "0.0.1"
+leftwm_versions = "*"
+
+[[theme]]
+name = "Coffee"
+repository = "https://github.com/lex148/leftwm-coffee/"
+commit = "*"
+version = "0.0.1"
+leftwm_versions = "*"
+
+[[theme]]
+name = "Soothe"
+repository = "https://github.com/b4skyx/leftwm-soothe/"
+commit = "*"
+version = "0.0.1"
+leftwm_versions = "*"
+
+[[theme]]
+name = "TNG"
+repository = "https://github.com/lex148/leftwm-tng/"
+commit = "*"
+version = "0.0.1"
+leftwm_versions = "*"
+
+[[theme]]
+name = "Windows XP"
+repository = "https://github.com/lex148/leftwm-windowsxp/"
+commit = "*"
+version = "0.0.1"
+leftwm_versions = "*"


### PR DESCRIPTION
Howdy,

This is part of a multi-commit PR for leftwm/leftwm, leftwm/leftwm-theme, and leftwm/leftwm-community-themes. 

The new utility will allow for easier installation of themes per leftwm/leftwm#27. The currently developed commands are as follows:
```
SUBCOMMANDS:
    add       downloads a theme
    help      Prints this message or the help of the given subcommand(s)
    list      lists installed LeftWM themes
    new       creates a new theme
    remove    removes an installed LeftWM theme
    search    fetches a list of LeftWM themes and searches for new ones
    set       sets your current theme and restarts LeftWM
    update    fetches updates to all themes
```

If I want to install the Coffee theme for example, I need to run the following:
```bash
leftwm-theme update
leftwm-theme add "Coffee"
leftwm-theme set "Coffee"
```

I'm sure the files could be better organized, and I trust someone will help with that. A few other commands were mentioned in leftwm/leftwm#27 that I'd like to get to, including `next` and the one mentioned in leftwm/leftwm#191 which is `leftwm-theme check` and `leftwm-check`.

Currently, the installer does not check if a theme is valid, it operates under the assumption that only files in known.toml will make it in, locked at a particular commit, so we know they're good. That would be a good next step I think. 

Best,
Mautamu